### PR TITLE
ref #10 🎨 検索機能を文字列入力型に変更した

### DIFF
--- a/src/routes/Methods.tsx
+++ b/src/routes/Methods.tsx
@@ -10,32 +10,136 @@ import {
   Image,
   Button,
   Box,
+  Input,
+  InputGroup,
+  InputRightElement,
+  useDisclosure,
 } from "@chakra-ui/react";
-import { useState } from "react";
-import TagSelector from "../components/method/TagSelector";
+import { useState, useRef, useEffect, useCallback } from "react";
+import { SearchIcon } from "@chakra-ui/icons";
 import { generateMethodContents } from "../utils/methodUtils";
 
 const Methods = () => {
-  const [selectedTag, setSelectedTag] = useState<string | null>(null);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [suggestions, setSuggestions] = useState<string[]>([]);
+  const [isSearching, setIsSearching] = useState(false);
   const methodContents = generateMethodContents();
+  const { isOpen, onOpen, onClose } = useDisclosure();
+  const inputRef = useRef<HTMLInputElement>(null);
 
-  // すべてのタグを取得
-  const allTags = Array.from(
-    new Set(methodContents.flatMap((content) => content.tags))
+  const generateSuggestions = useCallback(
+    (query: string) => {
+      if (!query) {
+        setSuggestions([]);
+        return;
+      }
+
+      const queryLower = query.toLowerCase();
+      const allSuggestions = new Set<string>();
+
+      methodContents.forEach((content) => {
+        // タイトルから候補を生成
+        if (content.title.toLowerCase().includes(queryLower)) {
+          allSuggestions.add(content.title);
+        }
+
+        // タグから候補を生成
+        content.tags.forEach((tag) => {
+          if (tag.toLowerCase().includes(queryLower)) {
+            allSuggestions.add(tag);
+          }
+        });
+      });
+
+      setSuggestions(Array.from(allSuggestions).slice(0, 5));
+    },
+    [methodContents]
   );
 
-  const filteredContents = selectedTag
-    ? methodContents.filter((content) => content.tags.includes(selectedTag))
+  useEffect(() => {
+    generateSuggestions(searchQuery);
+  }, [searchQuery, generateSuggestions]);
+
+  const filteredContents = isSearching
+    ? methodContents.filter((content) => {
+        const searchLower = searchQuery.toLowerCase();
+        return (
+          content.title.toLowerCase().includes(searchLower) ||
+          content.overview.toLowerCase().includes(searchLower) ||
+          content.tags.some((tag) => tag.toLowerCase().includes(searchLower))
+        );
+      })
     : methodContents;
+
+  const handleSearch = () => {
+    setIsSearching(true);
+    onClose();
+  };
+
+  const handleTagClick = (tag: string) => {
+    setSearchQuery(tag);
+    setIsSearching(true);
+  };
+
+  const handleSuggestionClick = (suggestion: string) => {
+    setSearchQuery(suggestion);
+    setIsSearching(true);
+    onClose();
+  };
 
   return (
     <Box p={4}>
-      <TagSelector
-        tags={allTags}
-        selectedTag={selectedTag}
-        onTagSelect={setSelectedTag}
-      />
-      <Stack spacing={4} mt={4}>
+      <Box position="relative" width="100%" maxW="600px" mb={4}>
+        <InputGroup>
+          <Input
+            placeholder="記事を検索"
+            value={searchQuery}
+            onChange={(e) => {
+              setSearchQuery(e.target.value);
+              setIsSearching(false);
+              onOpen();
+            }}
+            onFocus={onOpen}
+            ref={inputRef}
+          />
+          <InputRightElement width="4.5rem">
+            <Button
+              h="1.75rem"
+              size="sm"
+              onClick={handleSearch}
+              colorScheme="blue"
+            >
+              <SearchIcon color="gray.300" />
+            </Button>
+          </InputRightElement>
+        </InputGroup>
+
+        {isOpen && suggestions.length > 0 && (
+          <Box
+            position="absolute"
+            zIndex={1}
+            width="100%"
+            bg="white"
+            boxShadow="md"
+            borderRadius="md"
+            mt={0}
+          >
+            {suggestions.map((suggestion, index) => (
+              <Box
+                key={index}
+                p={2}
+                cursor="pointer"
+                _hover={{ bg: "gray.100" }}
+                onClick={() => handleSuggestionClick(suggestion)}
+              >
+                {suggestion}
+              </Box>
+            ))}
+          </Box>
+        )}
+      </Box>
+
+      <Stack spacing={4}>
         {filteredContents.map((content) => (
           <motion.div
             key={content.id}
@@ -66,6 +170,8 @@ const Methods = () => {
                         size="sm"
                         variant="outline"
                         colorScheme="gray"
+                        onClick={() => handleTagClick(tag)}
+                        _hover={{ bg: "gray.100" }}
                       >
                         {tag}
                       </Button>


### PR DESCRIPTION
- 文字列をタグ、タイトル、概要から検索し、一致する(部分文字列 | 完全文字列)がある場合にフィルタした検索結果を表示
- 文字列を入れた際に検索候補を表示

<img width="820" alt="スクリーンショット 2025-04-22 10 57 24" src="https://github.com/user-attachments/assets/c25f6a16-5678-4b6f-9fde-dabe8518bb4f" />
<img width="732" alt="スクリーンショット 2025-04-22 10 57 33" src="https://github.com/user-attachments/assets/643cd26d-e256-440a-9402-826a61a4667b" />
<img width="1193" alt="スクリーンショット 2025-04-22 10 57 45" src="https://github.com/user-attachments/assets/21283ebe-0e10-4f16-9584-65b3ff1f1817" />
