### PR TITLE
fix: add basename to Router for GitHub Pages compatibility (Issue #48)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,7 +13,7 @@ import "katex/dist/katex.mjs";
 
 const App = () => {
   return (
-    <Router>
+    <Router basename={process.env.PUBLIC_URL}>
       <Box minH="100vh" bg="slate.50">
         <Header title="（非公式）- 佐治研画像処理学習キット -" />
         <Sidebar />


### PR DESCRIPTION
- Add basename={process.env.PUBLIC_URL} to BrowserRouter
- Ensures React Router correctly handles routes under base path
- Works with existing 404.html redirect mechanism
- Fixes page reload 404 errors on GitHub Pages