### PR TITLE
♻️ refactor: メタデータの重複定義を解消 (#84)

### DIFF
--- a/src/content/Method1.tsx
+++ b/src/content/Method1.tsx
@@ -4,17 +4,6 @@ import React from "react";
 import { Box, Text, Image, List, ListItem, Flex } from "@chakra-ui/react";
 import abemaBagThreshold from "../components/image/abemaBag_threshold.jpg";
 
-// メタデータの定義
-export const methodMetadata = {
-  id: 1,
-  title: "2値化",
-  overview: "",
-  tags: ["画像処理", "2値化"],
-  image: abemaBagThreshold,
-  searchableContent:
-    "2値化 閾値 グレースケール 白黒 画像処理 二値化 threshold binary モノクロ 画素値 輝度 変換",
-};
-
 const Method1 = () => {
   return (
     <Box p={4} maxW="1200px" mx="auto">
@@ -32,7 +21,7 @@ const Method1 = () => {
             fontFamily="Arial"
             mb={2}
           >
-            {methodMetadata.title}
+            2値化
           </Text>
         </Box>
         {/* <Box flex="1" display="flex" justifyContent="center">

--- a/src/content/Method10.tsx
+++ b/src/content/Method10.tsx
@@ -19,21 +19,12 @@ import {
 } from "@chakra-ui/react";
 import { InlineMath, BlockMath } from "react-katex";
 
-// メタデータの定義
-export const methodMetadata = {
-  id: 10,
-  title: "Transformer",
-  overview: "Attention機構とVision Transformerによる画像処理を学ぶ",
-  tags: ["画像処理", "深層学習", "Transformer"],
-  searchableContent:
-    "Transformer ViT Vision Transformer Attention Self-Attention SWIN CLIP マルチモーダル DeiT",
-};
 
 const Method10 = () => {
   return (
     <Box p={4} maxW="1200px" mx="auto">
       <Text as="h1" fontSize="3xl" fontWeight="bold" fontFamily="Arial" mb={4}>
-        {methodMetadata.title}
+        Transformer
       </Text>
 
       <Text fontSize="md" fontFamily="Verdana" lineHeight="1.8" mb={6}>

--- a/src/content/Method11.tsx
+++ b/src/content/Method11.tsx
@@ -11,25 +11,12 @@ import {
   VStack,
 } from "@chakra-ui/react";
 import { InlineMath, BlockMath } from "react-katex";
-import templateMatchingImg from "../components/image/template_matching.png";
-
-// メタデータの定義
-export const methodMetadata = {
-  id: 11,
-  title: "テンプレートマッチング",
-  overview:
-    "画像内から特定のパターンを探し出すテンプレートマッチングの原理と実装を学ぶ",
-  tags: ["画像処理", "テンプレートマッチング", "物体検出", "パターン認識"],
-  image: templateMatchingImg,
-  searchableContent:
-    "テンプレートマッチング Template Matching SSD NCC ZNCC 類似度 物体検出 OpenCV パターン認識 相関",
-};
 
 const Method11 = () => {
   return (
     <Box p={4} maxW="1200px" mx="auto">
       <Text as="h1" fontSize="3xl" fontWeight="bold" fontFamily="Arial" mb={4}>
-        {methodMetadata.title}
+        テンプレートマッチング
       </Text>
 
       <Text fontSize="md" fontFamily="Verdana" lineHeight="1.8" mb={6}>

--- a/src/content/Method2.tsx
+++ b/src/content/Method2.tsx
@@ -17,16 +17,6 @@ import {
   ListItem,
 } from "@chakra-ui/react";
 
-// メタデータの定義
-export const methodMetadata = {
-  id: 2,
-  title: "背景差分法",
-  overview:
-    "動画から背景情報のみを取り出してみる。固定カメラ案件での活躍が期待できる。",
-  tags: ["画像処理", "背景差分法"],
-  searchableContent:
-    "背景差分法 動体検出 フレーム差分 移動物体 検出 background subtraction 動画処理 時系列 変化検出",
-};
 
 const Method2 = () => {
   const videoRef = useRef<HTMLVideoElement>(null);
@@ -57,12 +47,9 @@ const Method2 = () => {
   return (
     <Box p={4} maxW="1200px" mx="auto">
       <Text as="h1" fontSize="3xl" fontWeight="bold" fontFamily="Arial" mb={4}>
-        {methodMetadata.title}
+        背景差分法
       </Text>
 
-      {/* <Text fontSize="md" fontFamily="Verdana" lineHeight="1.8" mb={6}>
-        {methodMetadata.overview}
-      </Text> */}
 
       <Text
         as="h2"

--- a/src/content/Method3.tsx
+++ b/src/content/Method3.tsx
@@ -20,16 +20,6 @@ import {
 } from "@chakra-ui/react";
 import deepLearing from "../components/image/deepLearning.png";
 
-// メタデータの定義
-export const methodMetadata = {
-  id: 3,
-  title: "物体検出",
-  overview: "画像内の物体を検出し、位置と種類を特定する技術について学ぶ",
-  tags: ["画像処理", "深層学習", "物体検出"],
-  image: deepLearing,
-  searchableContent:
-    "物体検出 YOLO R-CNN Faster R-CNN SSD RetinaNet IoU mAP bounding box アンカーボックス object detection",
-};
 
 const Method3 = () => {
   return (
@@ -47,7 +37,7 @@ const Method3 = () => {
           fontFamily="Arial"
           mb={4}
         >
-          {methodMetadata.title}
+          物体検出
         </Text>
         <Box flex="1" display="flex" justifyContent="center">
           <Image

--- a/src/content/Method4.tsx
+++ b/src/content/Method4.tsx
@@ -19,16 +19,6 @@ import { useState } from "react";
 import HoughTransform from "../components/methodDetail/HoughTransform";
 import AbemaBag from "../components/image/abemaBag.jpg";
 import { InlineMath, BlockMath } from "react-katex";
-// メタデータの定義
-export const methodMetadata = {
-  id: 4,
-  title: "ハフ変換",
-  overview: "ハフ変換とは〜",
-  tags: ["画像処理", "ハフ変換"],
-  image: AbemaBag,
-  searchableContent:
-    "ハフ変換 直線検出 円検出 Hough transform エッジ検出 形状検出 パラメータ空間 投票",
-};
 
 const Method4 = () => {
   const [processTrigger, setProcessTrigger] = useState<boolean>(false);
@@ -58,7 +48,7 @@ const Method4 = () => {
           fontFamily="Arial"
           mb={4}
         >
-          {methodMetadata.title}
+          ハフ変換
         </Text>
         <Box flex="1" display="flex" justifyContent="center">
           <Image

--- a/src/content/Method5.tsx
+++ b/src/content/Method5.tsx
@@ -24,16 +24,6 @@ import Lenna from "../components/image/lenna.bmp";
 import BlurImage from "../components/image/2_move.png";
 import MedianImage from "../components/image/2_median.png";
 
-// メタデータの定義
-export const methodMetadata = {
-  id: 5,
-  title: "ノイズ除去を除去したい -フィルタ編-",
-  overview: "なかなか注目がいかないノイズ除去について述べる．実はかなり重要",
-  tags: ["画像処理", "ノイズ"],
-  image: Lenna,
-  searchableContent:
-    "ノイズ除去 フィルタ ガウシアンフィルタ メディアンフィルタ 平滑化 smoothing デノイジング ぼかし blur",
-};
 
 const Method5 = () => {
   const [processTriggerBlur, setProcessTriggerBlur] = useState<boolean>(false);
@@ -84,7 +74,7 @@ const Method5 = () => {
           fontFamily="Arial"
           mb={4}
         >
-          {methodMetadata.title}
+          ノイズ除去を除去したい -フィルタ編-
         </Text>
         <Box flex="1" display="flex" justifyContent="center">
           <Image

--- a/src/content/Method6.tsx
+++ b/src/content/Method6.tsx
@@ -18,15 +18,6 @@ import {
   Heading,
 } from "@chakra-ui/react";
 
-// メタデータの定義
-export const methodMetadata = {
-  id: 6,
-  title: "特徴点マッチング",
-  overview: "特徴点マッチングを使ってみよう",
-  tags: ["画像処理", "特徴点マッチング"],
-  searchableContent:
-    "特徴点マッチング SIFT SURF ORB 特徴量 キーポイント 対応点 feature matching descriptor",
-};
 
 const detectorData = [
   {
@@ -80,12 +71,12 @@ const Method6 = () => {
           fontFamily="Arial"
           mb={4}
         >
-          {methodMetadata.title}
+          特徴点マッチング
         </Text>
       </Flex>
 
       <Text fontSize="md" fontFamily="Verdana" lineHeight="1.8" mb={6}>
-        {methodMetadata.overview}
+        特徴点マッチングを使ってみよう
       </Text>
 
       <Text

--- a/src/content/Method7.tsx
+++ b/src/content/Method7.tsx
@@ -4,17 +4,6 @@ import { Box, Text, List, ListItem, Flex, Image } from "@chakra-ui/react";
 import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
 import { oneDark } from "react-syntax-highlighter/dist/esm/styles/prism";
 import pythonPC from "../components/image/python_in_pc.png";
-// メタデータの定義
-export const methodMetadata = {
-  id: 7,
-  title: "ループ書くときはNumPyを使おう",
-  overview:
-    "Pythonの画像処理って速度遅いな〜二重ループなんてやってられないよ;;と思っているそこのあなた向け",
-  tags: ["画像処理", "NumPy"],
-  image: pythonPC,
-  searchableContent:
-    "NumPy Python 配列 ベクトル化 高速化 行列演算 ndarray ループ最適化 パフォーマンス",
-};
 
 const Method7 = () => {
   return (
@@ -33,7 +22,7 @@ const Method7 = () => {
             fontFamily="Arial"
             mb={2}
           >
-            {methodMetadata.title}
+            ループ書くときはNumPyを使おう
           </Text>
         </Box>
         <Box flex="1" display="flex" justifyContent="center">

--- a/src/content/Method8.tsx
+++ b/src/content/Method8.tsx
@@ -18,22 +18,12 @@ import {
 } from "@chakra-ui/react";
 import { InlineMath, BlockMath } from "react-katex";
 
-// メタデータの定義
-export const methodMetadata = {
-  id: 8,
-  title: "オプティカルフロー",
-  overview:
-    "動画内の物体の動きをベクトル場として可視化し、密と疎の2つのアプローチを学ぶ",
-  tags: ["画像処理", "オプティカルフロー", "動き推定"],
-  searchableContent:
-    "オプティカルフロー optical flow 動き検出 Farneback Lucas-Kanade 密 疎 ベクトル場 動き推定 フロー 特徴点追跡 動画処理 モーション",
-};
 
 const Method9 = () => {
   return (
     <Box p={4} maxW="1200px" mx="auto">
       <Text as="h1" fontSize="3xl" fontWeight="bold" fontFamily="Arial" mb={4}>
-        {methodMetadata.title}
+        オプティカルフロー
       </Text>
 
       <Text fontSize="md" fontFamily="Verdana" lineHeight="1.8" mb={6}>

--- a/src/content/Method9.tsx
+++ b/src/content/Method9.tsx
@@ -19,21 +19,12 @@ import {
 } from "@chakra-ui/react";
 import { InlineMath, BlockMath } from "react-katex";
 
-// メタデータの定義
-export const methodMetadata = {
-  id: 9,
-  title: "画像認識(CNN)",
-  overview: "畳み込みニューラルネットワークによる画像認識の基礎を学ぶ",
-  tags: ["画像処理", "深層学習", "CNN"],
-  searchableContent:
-    "CNN 畳み込み 画像認識 ResNet VGG AlexNet 転移学習 データ拡張 classification convolutional neural network",
-};
 
 const Method9 = () => {
   return (
     <Box p={4} maxW="1200px" mx="auto">
       <Text as="h1" fontSize="3xl" fontWeight="bold" fontFamily="Arial" mb={4}>
-        {methodMetadata.title}
+        画像認識(CNN)
       </Text>
 
       <Text fontSize="md" fontFamily="Verdana" lineHeight="1.8" mb={6}>


### PR DESCRIPTION
## Summary

- `Method1〜11.tsx` から `export const methodMetadata = {...}` を削除
- `methodsMetadata.ts` をメタデータの唯一の定義場所として確立
- JSX 内で `{methodMetadata.title}` / `{methodMetadata.overview}` を参照していた箇所は文字列リテラルに置き換え
- `templateMatchingImg`（Method11）など、metadata のみで使用していた画像 import も合わせて削除

## Test plan

- [ ] `npm run build` が成功することを確認（ローカルで確認済み）
- [ ] 各記事ページ（/methods/1 〜 /methods/12）のタイトルが正しく表示されること
- [ ] 一覧ページ（/methods）のカード表示が変わらないこと

Closes #84