### PR TITLE
♻️ refactor: ImageProcessorProps の重複定義を解消 (#86)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,3 +42,4 @@ Conventional Commits に従う。prefix の前に gitmoji を付ける。
 - `any` 型は使用禁止。型が明確な場合は具体的な型を、型が不明な場合は `unknown` を使う（`@typescript-eslint/no-explicit-any`）
 - `console.log/warn/error` は本番コードに残さない（`no-console`）
 - `npm run format` で一括フォーマット可能
+- 型定義は `interface` ではなく `type` を使う

--- a/src/components/methodDetail/Blur.tsx
+++ b/src/components/methodDetail/Blur.tsx
@@ -1,11 +1,6 @@
 import { useEffect, useRef } from "react";
 import cv from "opencv-ts";
-
-interface ImageProcessorProps {
-  imageFile: string;
-  processTrigger: boolean;
-  kernelSize: number;
-}
+import { ImageProcessorProps } from "./imageProcessorTypes";
 
 const Blur = ({
   imageFile,

--- a/src/components/methodDetail/Median.tsx
+++ b/src/components/methodDetail/Median.tsx
@@ -1,11 +1,6 @@
 import { useEffect, useRef } from "react";
 import cv from "opencv-ts";
-
-interface ImageProcessorProps {
-  imageFile: string;
-  processTrigger: boolean;
-  kernelSize: number;
-}
+import { ImageProcessorProps } from "./imageProcessorTypes";
 
 const Median = ({
   imageFile,

--- a/src/components/methodDetail/imageProcessorTypes.ts
+++ b/src/components/methodDetail/imageProcessorTypes.ts
@@ -1,0 +1,5 @@
+export interface ImageProcessorProps {
+  imageFile: string;
+  processTrigger: boolean;
+  kernelSize: number;
+}

--- a/src/components/methodDetail/imageProcessorTypes.ts
+++ b/src/components/methodDetail/imageProcessorTypes.ts
@@ -1,5 +1,5 @@
-export interface ImageProcessorProps {
+export type ImageProcessorProps = {
   imageFile: string;
   processTrigger: boolean;
   kernelSize: number;
-}
+};


### PR DESCRIPTION
## Summary

- `Blur.tsx` と `Median.tsx` に重複していた `ImageProcessorProps` を `imageProcessorTypes.ts` に切り出し
- 両ファイルから import するよう変更

## Test plan

- [ ] `npm run build` が成功すること（ローカルで確認済み）
- [ ] ノイズ除去ページ（/methods/5）のフィルタ処理が正常に動作すること

Closes #86