### PR TITLE
🐛 fix: ホーム動画のグレー画面を解消 (#52)

### DIFF
--- a/src/routes/Home.tsx
+++ b/src/routes/Home.tsx
@@ -55,9 +55,6 @@ const Home = () => {
 
   useEffect(() => {
     if (videoRef.current && !hasError) {
-      videoRef.current.load();
-
-      // Small delay to ensure video is ready
       const timer = setTimeout(() => {
         if (videoRef.current) {
           const playPromise = videoRef.current.play();

--- a/src/routes/Home.tsx
+++ b/src/routes/Home.tsx
@@ -87,6 +87,7 @@ const Home = () => {
         w="100%"
         h="60vh"
         overflow="hidden"
+        bg="black"
         onClick={handleUserClick}
         cursor={needsInteraction ? "pointer" : "default"}
       >
@@ -107,6 +108,8 @@ const Home = () => {
               w="100%"
               h="100%"
               objectFit="cover"
+              opacity={isLoading ? 0 : 1}
+              transition="opacity 0.5s ease"
               onEnded={handleVideoEnd}
               onError={handleVideoError}
               onLoadStart={handleVideoLoadStart}


### PR DESCRIPTION
## 原因

動画ダウンロード中、ブラウザがデフォルトでグレーのプレースホルダーを描画する。ローディングオーバーレイが半透明（rgba 40%）だったためグレーが透けて見えていた。

## 変更内容

- コンテナ `Box` に `bg="black"` を追加 → ロード前の背景をグレーから黒に変更
- 動画要素に `opacity={isLoading ? 0 : 1}` と `transition="opacity 0.5s ease"` を追加 → ロード完了後に0.5秒でフェードイン

## Test plan

- [ ] ホームページ初回表示時にグレー画面が出ないこと
- [ ] 動画がじわっとフェードインすること
- [ ] 2本目の動画への切り替えも正常に動作すること

Closes #52