### PR TITLE
♻️ refactor: Home.tsx の動画再生ロジックをイベントドリブンに整理 (#91)

### DIFF
--- a/src/routes/Home.tsx
+++ b/src/routes/Home.tsx
@@ -77,7 +77,6 @@ const Home = () => {
               ref={videoRef}
               src={videoList[currentVideoIndex]}
               muted
-              loop={false}
               preload="auto"
               playsInline
               position="absolute"

--- a/src/routes/Home.tsx
+++ b/src/routes/Home.tsx
@@ -17,11 +17,9 @@ const Home = () => {
 
   const handleVideoEnd = () => {
     setCurrentVideoIndex((prevIndex) => (prevIndex + 1) % videoList.length);
-    setHasError(false);
-    errorCountRef.current = 0;
   };
 
-  const handleVideoError = (e?: unknown) => {
+  const handleVideoError = () => {
     errorCountRef.current += 1;
 
     if (errorCountRef.current >= videoList.length) {
@@ -47,7 +45,7 @@ const Home = () => {
         setNeedsInteraction(true);
         setIsLoading(false);
       } else {
-        handleVideoError(error);
+        handleVideoError();
       }
     });
   };
@@ -55,7 +53,7 @@ const Home = () => {
   const handleUserClick = () => {
     if (videoRef.current && needsInteraction) {
       videoRef.current.play().catch((error) => {
-        handleVideoError(error);
+        handleVideoError();
       });
       setNeedsInteraction(false);
     }

--- a/src/routes/Home.tsx
+++ b/src/routes/Home.tsx
@@ -1,5 +1,5 @@
 import { Box, Text, Flex, Heading } from "@chakra-ui/react";
-import { useState, useEffect, useRef } from "react";
+import { useState, useRef } from "react";
 import { AnimatedText } from "../components/AnimatedText";
 
 const videoList = [
@@ -24,7 +24,6 @@ const Home = () => {
   const handleVideoError = (e?: unknown) => {
     errorCountRef.current += 1;
 
-    // If we've tried all videos, stop trying
     if (errorCountRef.current >= videoList.length) {
       setHasError(true);
       setIsLoading(false);
@@ -42,6 +41,15 @@ const Home = () => {
     setIsLoading(false);
     setHasError(false);
     errorCountRef.current = 0;
+
+    videoRef.current?.play().catch((error) => {
+      if (error.name === "NotAllowedError") {
+        setNeedsInteraction(true);
+        setIsLoading(false);
+      } else {
+        handleVideoError(error);
+      }
+    });
   };
 
   const handleUserClick = () => {
@@ -52,30 +60,6 @@ const Home = () => {
       setNeedsInteraction(false);
     }
   };
-
-  useEffect(() => {
-    if (videoRef.current && !hasError) {
-      const timer = setTimeout(() => {
-        if (videoRef.current) {
-          const playPromise = videoRef.current.play();
-
-          if (playPromise !== undefined) {
-            playPromise.catch((error) => {
-              // Check if it's an autoplay policy error
-              if (error.name === "NotAllowedError") {
-                setNeedsInteraction(true);
-                setIsLoading(false);
-              } else {
-                handleVideoError(error);
-              }
-            });
-          }
-        }
-      }, 100);
-
-      return () => clearTimeout(timer);
-    }
-  }, [currentVideoIndex, hasError]);
 
   return (
     <div>
@@ -94,7 +78,6 @@ const Home = () => {
               as="video"
               ref={videoRef}
               src={videoList[currentVideoIndex]}
-              autoPlay
               muted
               loop={false}
               preload="auto"


### PR DESCRIPTION
## 変更内容

### useEffect の削除
- `onCanPlay` イベントで `play()` を呼ぶイベントドリブンな実装に変更
- `autoPlay` 属性を削除（`play()` を明示的に呼ぶため不要）
- 100ms の根拠のない `setTimeout` を削除
- `playPromise !== undefined` チェックを削除（現代ブラウザでは不要）
- `videoRef.current` の二重チェックを解消
- `useEffect` の import を削除

### その他のリファクタリング
- `handleVideoEnd` から `setHasError` / `errorCountRef` リセットを削除（`handleVideoCanPlay` で実行されるため不要）
- `handleVideoError` の未使用パラメータ `e` を削除
- デフォルト値と同じ `loop={false}` を削除

## Test plan

- [x] ホームページで動画が自動再生されること
- [x] 1本目が終わったら2本目に切り替わること
- [x] ネットワークタブで動画リクエストが1回だけ発生すること

Closes #91