### PR TITLE
🔧 chore: CI の Node.js バージョンを v22 に統一し ESLint を有効化 (#104)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '22'
           cache: 'npm'
           
       - name: Install dependencies
@@ -36,8 +36,6 @@ jobs:
         
       - name: Build
         run: npm run build
-        env:
-          CI: false  # Treat warnings as warnings, not errors
           
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
## 概要

CI/CD パイプラインの設定を2点修正する。

## 変更内容

- `node-version` を `'18'` → `'22'` に変更（mise の `.mise.toml` と統一）
- `CI: false` を削除し、ESLint エラーをビルド失敗として検知できるようにする

## 確認済み事項

- ローカルで `npm run build` を実行し、警告・エラーなしでビルドが通ることを確認済み

## レビュー観点

- `.mise.toml` の `node = "22.16.0"` と CI の `node-version: '22'` が一致していること
- この PR 自体の Checks が緑になること

Closes #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)