### PR TITLE
🐛 fix: 記事フェッチの二重呼び出しを TanStack Query で解消 (#99)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@fortawesome/free-brands-svg-icons": "^6.6.0",
         "@fortawesome/free-solid-svg-icons": "^6.6.0",
         "@fortawesome/react-fontawesome": "^0.2.2",
+        "@tanstack/react-query": "^5.101.0",
         "@testing-library/jest-dom": "^5.17.0",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
@@ -5064,6 +5065,32 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/gregberge"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.101.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.101.0.tgz",
+      "integrity": "sha512-cQetA74EB+seWySv1TTKr828TnP0u39m6LykwDXIo84SNortpDkp30TMEjkqtYCNP9c40uT/iwl6MLiufEt0Ow==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.101.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.101.0.tgz",
+      "integrity": "sha512-rLlJXSpkqfizLWgkR5+eLeIk0MvTx/meEIR7LRjxic+qxiQP8zVjq7BqQkiCMNLQBlLfuOLqqr6KO5GtrDlmSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.101.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
       }
     },
     "node_modules/@testing-library/dom": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@fortawesome/free-brands-svg-icons": "^6.6.0",
     "@fortawesome/free-solid-svg-icons": "^6.6.0",
     "@fortawesome/react-fontawesome": "^0.2.2",
+    "@tanstack/react-query": "^5.101.0",
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",

--- a/src/components/methodDetail/MethodDetail.tsx
+++ b/src/components/methodDetail/MethodDetail.tsx
@@ -13,11 +13,13 @@ const MethodDetail = () => {
   const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
+    const controller = new AbortController();
+
     setHasError(false);
     setMarkdown(null);
     setIsLoading(true);
 
-    fetch(`${WORKER_URL}/articles/method${id}`)
+    fetch(`${WORKER_URL}/articles/method${id}`, { signal: controller.signal })
       .then((res) => {
         if (!res.ok) throw new Error("Not Found");
         return res.text();
@@ -25,12 +27,15 @@ const MethodDetail = () => {
       .then((text) => {
         setMarkdown(text);
       })
-      .catch(() => {
+      .catch((err: unknown) => {
+        if (err instanceof DOMException && err.name === "AbortError") return;
         setHasError(true);
       })
       .finally(() => {
         setIsLoading(false);
       });
+
+    return () => controller.abort();
   }, [id]);
 
   if (isLoading) {

--- a/src/components/methodDetail/MethodDetail.tsx
+++ b/src/components/methodDetail/MethodDetail.tsx
@@ -14,12 +14,12 @@ const fetchArticle = async (id: string): Promise<string> => {
 
 const MethodDetail = () => {
   const { id } = useParams<{ id: string }>();
-  const safeId = id ?? "";
+  const articleId = id ?? "";
 
   const { data: markdown, isLoading, isError } = useQuery({
-    queryKey: ["article", safeId],
-    queryFn: () => fetchArticle(safeId),
-    enabled: safeId !== "",
+    queryKey: ["article", articleId],
+    queryFn: () => fetchArticle(articleId),
+    enabled: articleId !== "",
     retry: false,
   });
 

--- a/src/components/methodDetail/MethodDetail.tsx
+++ b/src/components/methodDetail/MethodDetail.tsx
@@ -14,11 +14,12 @@ const fetchArticle = async (id: string): Promise<string> => {
 
 const MethodDetail = () => {
   const { id } = useParams<{ id: string }>();
+  const safeId = id ?? "";
 
   const { data: markdown, isLoading, isError } = useQuery({
-    queryKey: ["article", id],
-    queryFn: () => fetchArticle(id!),
-    enabled: !!id,
+    queryKey: ["article", safeId],
+    queryFn: () => fetchArticle(safeId),
+    enabled: safeId !== "",
     retry: false,
   });
 

--- a/src/components/methodDetail/MethodDetail.tsx
+++ b/src/components/methodDetail/MethodDetail.tsx
@@ -1,42 +1,26 @@
-import { useEffect, useState } from "react";
 import { useParams, Link } from "react-router-dom";
 import { Box, Heading, Text, Button, Spinner, Center } from "@chakra-ui/react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
+import { useQuery } from "@tanstack/react-query";
 
 const WORKER_URL = "https://articles-worker.a-sakuramotyo.workers.dev";
 
+const fetchArticle = async (id: string): Promise<string> => {
+  const res = await fetch(`${WORKER_URL}/articles/method${id}`);
+  if (!res.ok) throw new Error("Not Found");
+  return res.text();
+};
+
 const MethodDetail = () => {
   const { id } = useParams<{ id: string }>();
-  const [markdown, setMarkdown] = useState<string | null>(null);
-  const [hasError, setHasError] = useState(false);
-  const [isLoading, setIsLoading] = useState(true);
 
-  useEffect(() => {
-    const controller = new AbortController();
-
-    setHasError(false);
-    setMarkdown(null);
-    setIsLoading(true);
-
-    fetch(`${WORKER_URL}/articles/method${id}`, { signal: controller.signal })
-      .then((res) => {
-        if (!res.ok) throw new Error("Not Found");
-        return res.text();
-      })
-      .then((text) => {
-        setMarkdown(text);
-      })
-      .catch((err: unknown) => {
-        if (err instanceof DOMException && err.name === "AbortError") return;
-        setHasError(true);
-      })
-      .finally(() => {
-        setIsLoading(false);
-      });
-
-    return () => controller.abort();
-  }, [id]);
+  const { data: markdown, isLoading, isError } = useQuery({
+    queryKey: ["article", id],
+    queryFn: () => fetchArticle(id!),
+    enabled: !!id,
+    retry: false,
+  });
 
   if (isLoading) {
     return (
@@ -46,7 +30,7 @@ const MethodDetail = () => {
     );
   }
 
-  if (hasError) {
+  if (isError) {
     return (
       <Box textAlign="center" py={20}>
         <Heading size="2xl" mb={4}>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,6 +4,7 @@ import "./index.css";
 import App from "./App";
 import reportWebVitals from "./reportWebVitals";
 import { ChakraProvider } from "@chakra-ui/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import theme from "./theme";
 
 // Fonts
@@ -12,14 +13,18 @@ import "@fontsource/inter/700.css";
 import "@fontsource/noto-sans-jp/400.css";
 import "@fontsource/noto-sans-jp/700.css";
 
+const queryClient = new QueryClient();
+
 const root = ReactDOM.createRoot(
   document.getElementById("root") as HTMLElement,
 );
 root.render(
   <React.StrictMode>
-    <ChakraProvider theme={theme}>
-      <App />
-    </ChakraProvider>
+    <QueryClientProvider client={queryClient}>
+      <ChakraProvider theme={theme}>
+        <App />
+      </ChakraProvider>
+    </QueryClientProvider>
   </React.StrictMode>,
 );
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -13,7 +13,11 @@ import "@fontsource/inter/700.css";
 import "@fontsource/noto-sans-jp/400.css";
 import "@fontsource/noto-sans-jp/700.css";
 
-const queryClient = new QueryClient();
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: { staleTime: Infinity },
+  },
+});
 
 const root = ReactDOM.createRoot(
   document.getElementById("root") as HTMLElement,


### PR DESCRIPTION
## 背景

React 18 の `StrictMode` が開発環境で `useEffect` を意図的に二重実行するため、記事詳細ページを開くたびに Worker へのリクエストが2回飛んでいた。

## 原因

`src/index.tsx` で `<React.StrictMode>` をルートに設定しており、React 18 では開発環境に限りコンポーネントを「マウント → アンマウント → 再マウント」する。これにより `useEffect` 内の `fetch` が2回実行されていた。

## 対応

`useEffect` + `fetch` の実装を **TanStack Query (`useQuery`)** に置き換えた。

TanStack Query は同一 `queryKey` に対するリクエストを内部で重複排除（deduplication）するため、StrictMode の二重マウントが起きてもリクエストは1本しか出ない。

### 変更内容

- `@tanstack/react-query` をインストール
- `src/index.tsx`: `QueryClientProvider` でアプリ全体をラップ
- `src/components/methodDetail/MethodDetail.tsx`: `useEffect` + `useState` × 3 + `AbortController` を `useQuery` 1つに置き換え

### Before / After

```ts
// Before
const [markdown, setMarkdown] = useState(null);
const [hasError, setHasError] = useState(false);
const [isLoading, setIsLoading] = useState(true);
useEffect(() => {
  const controller = new AbortController();
  fetch(url, { signal: controller.signal }) ...
  return () => controller.abort();
}, [id]);

// After
const { data: markdown, isLoading, isError } = useQuery({
  queryKey: ["article", id],
  queryFn: () => fetchArticle(id!),
  retry: false,
});
```

## 副次的な改善

- 同じ記事に戻った際、キャッシュが効いて**再フェッチが走らない**ようになった
- ローディング・エラー管理のボイラープレートが削減された

## テスト

- [ ] 記事詳細ページを開き、Network タブでリクエストが1本のみ（❌なし）であることを確認
- [ ] 存在しない記事 URL で 404 画面が表示されることを確認
- [ ] 一度開いた記事に戻ったとき、再フェッチが走らないことを確認

Closes #99

🤖 Generated with [Claude Code](https://claude.com/claude-code)