### PR TITLE
✨ feat: フッターの著作権年を動的に取得するよう変更

### DIFF
--- a/src/components/footer/Footer.tsx
+++ b/src/components/footer/Footer.tsx
@@ -26,7 +26,7 @@ const Footer = () => {
         justify="center"
         align="center"
       >
-        <Text fontSize="sm">© 2024 Hitoshi Sauji. All rights reserved</Text>
+        <Text fontSize="sm">© {new Date().getFullYear()} Hitoshi Sauji. All rights reserved</Text>
       </Container>
     </Box>
   );


### PR DESCRIPTION
## Summary
- `Footer.tsx` の著作権年をハードコードの `2024` から `new Date().getFullYear()` に変更
- 年が変わっても自動で現在年が表示されるようになった

## Test plan
- [ ] フッターに現在年（2026）が表示されていることを確認

closes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)