### PR TITLE
fix: CI を pnpm 対応に修正

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,17 +25,22 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 8
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: '22'
-          cache: 'npm'
-          
+          cache: 'pnpm'
+
       - name: Install dependencies
-        run: npm ci
-        
+        run: pnpm install --frozen-lockfile
+
       - name: Build
-        run: npm run build
+        run: pnpm build
           
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
## Summary

- `pnpm/action-setup@v4` を追加して pnpm をセットアップ
- `cache: npm` → `cache: pnpm` に変更
- `npm ci` → `pnpm install --frozen-lockfile` に変更
- `npm run build` → `pnpm build` に変更

closes #111

## Test plan

- [x] CI が通ることを確認
- [x] GitHub Pages へのデプロイが成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)