### PR TITLE
📝 docs: PR規約をRULES.mdに追加しPRテンプレートを作成

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,7 @@
 {
+  "attribution": {
+    "pr": ""
+  },
   "hooks": {
     "PostToolUse": [
       {

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,13 @@
+closes #
+
+## Summary
+
+<!-- 変更内容を箇条書きで -->
+
+## Test plan
+
+<!-- 動作確認の手順・チェックリスト -->
+
+- [ ]
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,13 +1,11 @@
 closes #
 
-## Summary
+## 概要
 
 <!-- 変更内容を箇条書きで -->
 
-## Test plan
+## 動作確認
 
 <!-- 動作確認の手順・チェックリスト -->
 
 - [ ]
-
-🤖 Generated with [Claude Code](https://claude.com/claude-code)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,3 @@
 # 開発ルール
 
 [RULES.md](RULES.md) を参照。
-
-PR 作成時に `🤖 Generated with Claude Code` の行を付けない。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,5 @@
 # 開発ルール
 
 [RULES.md](RULES.md) を参照。
+
+PR 作成時に `🤖 Generated with Claude Code` の行を付けない。

--- a/RULES.md
+++ b/RULES.md
@@ -9,10 +9,10 @@
 
 ## PR 規約
 
-- PR 本文に必ず `closes #[issue番号]` を記載する（マージ時に issue が自動 close される）
+- PR 本文に必ず `closes #[issue番号]` を記載する
 - PR タイトルは 70 文字以内、概要は本文に書く
 - PR 本文は `.github/PULL_REQUEST_TEMPLATE.md` のテンプレートに従う
-- ユーザーから「push して」と依頼された場合は push と PR 作成を一度に行う
+- push の指示があった場合は push と PR 作成を一度に行う
 
 ## コミット規約
 

--- a/RULES.md
+++ b/RULES.md
@@ -9,8 +9,8 @@
 
 ## PR 規約
 
-- PR 本文に必ず `closes #[issue番号]` を記載する（マージ時に issue が自動 close される）
-- PR タイトルは 70 文字以内、概要は本文に書く
+- PR 本文に必ず `closes #[issue番号]` を記載する
+- PR タイトルは 70 文字以内で対応し、概要は本文に書く
 - PR 本文は `.github/PULL_REQUEST_TEMPLATE.md` のテンプレートに従う
 
 ## コミット規約

--- a/RULES.md
+++ b/RULES.md
@@ -9,9 +9,10 @@
 
 ## PR 規約
 
-- PR 本文に必ず `closes #[issue番号]` を記載する
-- PR タイトルは 70 文字以内で対応し、概要は本文に書く
+- PR 本文に必ず `closes #[issue番号]` を記載する（マージ時に issue が自動 close される）
+- PR タイトルは 70 文字以内、概要は本文に書く
 - PR 本文は `.github/PULL_REQUEST_TEMPLATE.md` のテンプレートに従う
+- ユーザーから「push して」と依頼された場合は push と PR 作成を一度に行う
 
 ## コミット規約
 

--- a/RULES.md
+++ b/RULES.md
@@ -7,6 +7,12 @@
 - ブランチ名: `feature/[issue番号]_[概要]`（例: `feature/84_eslint-setup`）
 - 作業完了後は PR を作成して `main` へマージする
 
+## PR 規約
+
+- PR 本文に必ず `closes #[issue番号]` を記載する（マージ時に issue が自動 close される）
+- PR タイトルは 70 文字以内、概要は本文に書く
+- PR 本文は `.github/PULL_REQUEST_TEMPLATE.md` のテンプレートに従う
+
 ## コミット規約
 
 Conventional Commits に従う。prefix の前に gitmoji を付ける。


### PR DESCRIPTION
closes #116

## Summary

- `RULES.md` に PR 規約セクションを追加
  - `closes #XXX` の必須記載（issue 自動 close）
  - push 依頼時は PR 作成まで一度に行うルールを追記
- `.github/PULL_REQUEST_TEMPLATE.md` を新規作成（手動 PR 作成時にもテンプレートを適用）

## Test plan

- [ ] GitHub で新規 PR 作成時にテンプレートが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)