### PR TITLE
RULES.md を .claude/rules/ に分割してコンテキスト効率を改善する

### DIFF
--- a/.claude/rules/article.md
+++ b/.claude/rules/article.md
@@ -1,0 +1,23 @@
+# 記事執筆ガイドライン
+
+記事は Cloudflare R2（バケット: `b3semi-articles`）に Markdown ファイルとして管理している。
+編集・執筆には `/edit-article <記事ID>` を使う。
+
+## 対象読者・トーン
+
+- 対象: 画像処理を学び始めた大学生・研究室の学生
+- トーン: 丁寧だが堅すぎない「です/ます」調
+- 理論より「実際に動かしたらこうなった」という実体験ベースの内容を優先する
+
+## 記事の構成原則
+
+- 理論説明は冒頭1〜2段落に留める（詳細な数式・アルゴリズム説明は不要）
+- 各課題・トピックは「現象 → 原因 → 対処法」の構成で書く
+- 各節は独立して読める（前の節を読まないと意味が取れない構成は避ける）
+- コード例は Python + OpenCV で書く
+
+## 記事インフラ
+
+- 取得: `https://articles-worker.a-sakuramotyo.workers.dev/articles/method{ID}`
+- 書き戻し: `wrangler r2 object put b3semi-articles/method{ID}.md --file <file> --remote`（`cloudflare/articles-worker` ディレクトリで実行）
+- Write ツールで `/tmp/*.md` に保存すると markdownlint が自動実行される

--- a/.claude/rules/code-style.md
+++ b/.claude/rules/code-style.md
@@ -1,0 +1,12 @@
+---
+paths: src/**/*.{ts,tsx}
+---
+
+# コードスタイル
+
+- フォーマットは **Prettier** で統一（保存時に自動適用）
+- **ESLint** の警告を残したままコミットしない
+- `any` 型は使用禁止。型が明確な場合は具体的な型を、型が不明な場合は `unknown` を使う（`@typescript-eslint/no-explicit-any`）
+- `console.log/warn/error` は本番コードに残さない（`no-console`）
+- `npm run format` で一括フォーマット可能
+- 型定義は `interface` ではなく `type` を使う

--- a/.claude/rules/core.md
+++ b/.claude/rules/core.md
@@ -1,4 +1,4 @@
-# 開発ルール詳細
+# 開発ルール（コア）
 
 ## ブランチ運用
 
@@ -53,36 +53,3 @@ Conventional Commits に従う。prefix の前に gitmoji を付ける。
 
 - サブエージェントに**一部の処理だけ**委ねたい場合は fresh エージェントを使う。`fork` は会話コンテキスト全体（スキル指示を含む）を引き継ぐため、スキルのパイプライン全体を実行してしまう
 - パイプラインのループ制御（継続・終了判断）は常に**親（スキルを実行している Claude）が持つ**
-
-## 記事執筆ガイドライン
-
-記事は Cloudflare R2（バケット: `b3semi-articles`）に Markdown ファイルとして管理している。
-編集・執筆には `/edit-article <記事ID>` を使う。
-
-### 対象読者・トーン
-
-- 対象: 画像処理を学び始めた大学生・研究室の学生
-- トーン: 丁寧だが堅すぎない「です/ます」調
-- 理論より「実際に動かしたらこうなった」という実体験ベースの内容を優先する
-
-### 記事の構成原則
-
-- 理論説明は冒頭1〜2段落に留める（詳細な数式・アルゴリズム説明は不要）
-- 各課題・トピックは「現象 → 原因 → 対処法」の構成で書く
-- 各節は独立して読める（前の節を読まないと意味が取れない構成は避ける）
-- コード例は Python + OpenCV で書く
-
-### 記事インフラ
-
-- 取得: `https://articles-worker.a-sakuramotyo.workers.dev/articles/method{ID}`
-- 書き戻し: `wrangler r2 object put b3semi-articles/method{ID}.md --file <file> --remote`（`cloudflare/articles-worker` ディレクトリで実行）
-- Write ツールで `/tmp/*.md` に保存すると markdownlint が自動実行される
-
-## コードスタイル
-
-- フォーマットは **Prettier** で統一（保存時に自動適用）
-- **ESLint** の警告を残したままコミットしない
-- `any` 型は使用禁止。型が明確な場合は具体的な型を、型が不明な場合は `unknown` を使う（`@typescript-eslint/no-explicit-any`）
-- `console.log/warn/error` は本番コードに残さない（`no-console`）
-- `npm run format` で一括フォーマット可能
-- 型定義は `interface` ではなく `type` を使う

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,3 @@
 # 開発ルール
 
-`.claude/rules/` 内のファイルを参照。Claude Code がセッション起動時に自動ロードする。
+`.claude/rules/` 内のファイルを参照。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,3 @@
 # 開発ルール
 
-[RULES.md](RULES.md) を参照。
+`.claude/rules/` 内のファイルを参照。Claude Code がセッション起動時に自動ロードする。


### PR DESCRIPTION
## 概要

- `RULES.md` を廃止し、`.claude/rules/` ディレクトリへ分割
- Claude Code がセッション起動時に自動スキャン・注入するネイティブ機構を活用する

## 変更内容

| ファイル | 内容 |
|---|---|
| `.claude/rules/core.md` | ブランチ運用・PR 規約・コミット規約・Claude との作業ルール（常時ロード） |
| `.claude/rules/code-style.md` | コードスタイル（`paths: src/**/*.{ts,tsx}` で将来の条件付きロードに備える） |
| `.claude/rules/article.md` | 記事執筆ガイドライン |
| `CLAUDE.md` | `RULES.md` 参照を `.claude/rules/` の説明に変更 |
| `RULES.md` | 削除 |

## テスト計画

- [ ] 新しいセッションで Claude Code を起動し、ルールが読み込まれていることを確認する

closes #119