### PR TITLE
✨ feat: 差分法記事(method14)を追加し、Methodsページにカードを追加

### DIFF
--- a/src/data/methodsMetadata.ts
+++ b/src/data/methodsMetadata.ts
@@ -135,4 +135,13 @@ export const methodsMetadata: MethodContent[] = [
     searchableContent:
       "ベイジアンフィルタ パーティクルフィルタ 物体追跡 particle filter 粒子 縮退 リサンプリング オクルージョン 尤度関数 状態推定 確率分布 tracking",
   },
+  {
+    id: 14,
+    title: "差分法で動体を検出する",
+    overview:
+      "フレーム間差分法・MOG2・奥行き方向の検出問題など、実装時に詰まりやすい課題と対処法をまとめる。",
+    tags: ["画像処理", "動体検出", "背景差分法", "MOG2"],
+    searchableContent:
+      "差分法 フレーム間差分 背景差分 MOG2 動体検出 moving object detection background subtraction ゴースト 照明変化 影 オプティカルフロー 奥行き 接近 varThreshold learningRate",
+  },
 ];


### PR DESCRIPTION
## Summary

- 差分法（フレーム間差分法・MOG2・奥行き方向検出）の実運用記事を method14 として R2 に新規作成
- `src/data/methodsMetadata.ts` に method14 のカードエントリを追加し、Methods ページに表示されるようにした

## 変更内容

- **R2記事**: `b3semi-articles/method14.md` を新規作成（`https://articles-worker.a-sakuramotyo.workers.dev/articles/method14`）
- **カード**: `methodsMetadata` に id=14「差分法で動体を検出する」エントリを追加

## 記事の構成

- フレーム間差分法の実運用課題（穴あき・ゴースト・低速物体・照明変化）
- 背景差分法（MOG2）の実運用課題（初期化・影・動的背景・背景モデルのゴースト）
- 奥行き方向（Z軸）の検出問題と4つの対処法

## Test plan

- [ ] Methods ページに「差分法で動体を検出する」カードが表示される
- [ ] カードクリックで記事ページに遷移し内容が表示される

closes #134