### PR TITLE
🐛 fix: ローカル開発で記事取得が CORS で404になる問題を解消

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,4 +4,9 @@ import react from "@vitejs/plugin-react";
 export default defineConfig({
   plugins: [react()],
   base: "/saji-image-processing-web/",
+  // articles-worker の CORS 許可リスト（http://localhost:3000）に合わせる。
+  // 別ポートにフォールバックすると許可リスト外の origin になり記事取得が
+  // CORS で弾かれ 404 になる（#143）ため、strictPort で衝突時は明示的に落とす。
+  server: { port: 3000, strictPort: true },
+  preview: { port: 3000, strictPort: true },
 });


### PR DESCRIPTION
closes #143

## 概要

### 背景

`pnpm dev`（Vite デフォルトの port 5173）で起動すると記事取得が articles-worker の CORS 許可リストで弾かれ、`/Methods/:id` が全て 404 表示になっていた。#113 の Vite 移行以降、ローカル開発では記事表示が壊れたままだった。

### 変更内容

- `vite.config.ts` の `server`・`preview` を `port: 3000` に固定し、dev/preview サーバを worker の CORS 許可リストにある `http://localhost:3000` で起動するようにした
- 併せて `strictPort: true` を指定し、3000 が使用中のときに別ポートへフォールバックして許可リスト外 origin で CORS 404 が黙って再発するのを防いだ（衝突時は明示的にエラーで停止する）

## 動作確認

- [ ] `pnpm dev` を実行し、起動ログの Local が `http://localhost:3000/saji-image-processing-web/` になっている
- [ ] 上記 URL で `/Methods` を開き、任意のカードの「View More」から `/methods/14` へ遷移して記事本文が表示される（404 にならない）
- [ ] 記事ページで DevTools の Console にエラーが出ておらず、Network タブで `articles/method14` が **200** を返している
- [ ] port 3000 を別プロセスが占有した状態で `pnpm dev` を実行すると `Port 3000 is already in use` で停止する（別ポートに逃げない）

## レビュー観点

- 方式の選択: worker への 5173 追加（再デプロイ要）ではなく、フロント側で port を 3000 に固定する案を採用した。worker の許可リスト（CRA 由来の 3000）を変更せず再デプロイ不要で完結するため。5173 のまま統一したい場合は worker 側修正に切り替える判断もある
- DX: `strictPort` により衝突時は黙って CORS 404 に陥る代わりに即エラーになる。ポートを占有しがちな開発者にとって挙動が変わる点