### PR TITLE
✨ feat: 射影変換の記事を追加し記事一覧に表示する

### DIFF
--- a/src/data/methodsMetadata.ts
+++ b/src/data/methodsMetadata.ts
@@ -144,4 +144,13 @@ export const methodsMetadata: MethodContent[] = [
     searchableContent:
       "差分法 フレーム間差分 背景差分 MOG2 動体検出 moving object detection background subtraction ゴースト 照明変化 影 オプティカルフロー 奥行き 接近 varThreshold learningRate",
   },
+  {
+    id: 15,
+    title: "射影変換で空撮映像を直下視点に変換する",
+    overview:
+      "ドローンの斜め空撮映像を鳥瞰図に変換する。動画に適用したときのドリフト・揺れ・平面仮定の破綻など、実運用で詰まる課題と対処法をまとめる。",
+    tags: ["画像処理", "射影変換", "ホモグラフィ", "空撮映像"],
+    searchableContent:
+      "射影変換 ホモグラフィ homography perspective transform 鳥瞰図 直下視点 ドローン 空撮 warpPerspective findHomography getPerspectiveTransform RANSAC ドリフト 平面仮定 対応点 速度計測 定点観察",
+  },
 ];


### PR DESCRIPTION
closes #147

## 概要

### 背景

ドローン等の斜め空撮映像を直下視点に変換する射影変換は、定点観察や車両速度の違反検知に応用できる一方、動画に適用すると対応点のズレやドリフトで精度が悪化しやすい。射影変換のおさらいと、動画運用時の課題・対処法をまとめた記事を追加する。

### 変更内容

- 記事本文 `method15.md` を R2 バケット `b3semi-articles` にアップロード（編集→3体並列レビュー→再編集の3イテレーションで品質改善済み）
- `src/data/methodsMetadata.ts` に id:15（射影変換）のメタデータを追加し、記事一覧・検索に表示されるようにした

## 動作確認

- [ ] `curl -s https://articles-worker.a-sakuramotyo.workers.dev/articles/method15 | head -20` で記事冒頭が返る（200）
- [ ] `npm run dev` でトップの記事一覧に「射影変換で空撮映像を直下視点に変換する」が表示され、クリックで記事本文が描画される
- [ ] 検索ボックスに「ホモグラフィ」「射影変換」を入力すると本記事がヒットする
- [ ] 記事詳細ページでコードブロック（Python + OpenCV）が正しくハイライト表示される

## レビュー観点

- 記事本文の技術的正確性: 最終レビューで「Lucas-Kanade・goodFeaturesToTrack の初出説明の深さ」など軽微な指摘が残っている。記事として許容範囲かの判断をお願いしたい
- `methodsMetadata.ts` の overview・tags・searchableContent の文言が既存記事の粒度と揃っているか
- 記事詳細ページ表示時の DX（Network タブで method15 取得が1回で済んでいるか、コンソールにエラーが出ていないか）